### PR TITLE
79 add a join player option to the vsls join command

### DIFF
--- a/S4J/pom.xml
+++ b/S4J/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.protoxon</groupId>
         <artifactId>sls-monorepo</artifactId>
-        <version>1.0.0</version>
+        <version>1.0.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/vsls/README.md
+++ b/vsls/README.md
@@ -68,6 +68,13 @@ In-game and console commands are documented here:
 
 Most admin operations use the `/sls` command tree and require `sls.command.admin` where noted in that document.
 
+Useful player-facing commands include:
+
+- `/sls list` - Show active vSLS servers and player counts.
+- `/sls find <player>` - Show which vSLS server a player is currently on.
+- `/sls join player <player>` - Join the vSLS server that player is currently on.
+- `/sls dequeue` - Leave matchmaking or direct-server queues.
+
 ## License
 
 See [LICENSE](LICENSE) in this directory.

--- a/vsls/command_docs.md
+++ b/vsls/command_docs.md
@@ -145,6 +145,7 @@
 /sls join <blueprint_type> <blueprint_id>
 /sls join <blueprint_type> <blueprint_id> [all | local | <player>]
 /sls join player <player>
+/sls join player <player> --force
 ```
 
 **Arguments:**
@@ -155,12 +156,17 @@
   - `local` - Connects all players on the same server as the command sender
   - `<player>` - Connects a single specific player by username
 - `player` - When used as `/sls join player <player>`, connects you to the SLS server that player is currently on
+- `--force` - Admin-only confirmation flag for joining a player's server even when the target server is at its blueprint matchmaking capacity
 
 **Details:**
 - If no player argument is provided, the command executor is connected to the server
 - The command automatically handles server creation, starting, and waiting for readiness
 - Requires admin permission to join other players; players can join themselves without permission
 - `/sls join player <player>` is available to players and only works when the target player is currently on a registered SLS server
+- `/sls join player <player>` respects blueprint matchmaking capacity rules for normal players
+- If an admin tries to join a full target server, vSLS shows a warning with a clickable `Join Anyway` confirmation that runs `/sls join player <player> --force`
+- `/sls join player <player> --force` requires `sls.command.admin`
+- Player names and server IDs in the join output include hover details to make it easier to confirm the target
 
 ---
 
@@ -178,6 +184,7 @@
 **Details:**
 - Displays the player's current SLS composite server ID, such as `block_hunt.x82odk`
 - If the player is offline or not currently on an SLS server, the command displays an error message
+- Player names and server IDs include hover details such as UUID, current server, server status, blueprint, and player count
 
 ---
 

--- a/vsls/command_docs.md
+++ b/vsls/command_docs.md
@@ -9,6 +9,7 @@
 - [Create Command](#create-command)
 - [Start Command](#start-command)
 - [Join Command](#join-command)
+- [Find Command](#find-command)
 - [System Command](#system-command)
 - [Console Command](#console-command)
 - [Blueprint Command](#blueprint-command)
@@ -143,6 +144,7 @@
 ```
 /sls join <blueprint_type> <blueprint_id>
 /sls join <blueprint_type> <blueprint_id> [all | local | <player>]
+/sls join player <player>
 ```
 
 **Arguments:**
@@ -152,11 +154,30 @@
   - `all` - Connects all players currently on the proxy
   - `local` - Connects all players on the same server as the command sender
   - `<player>` - Connects a single specific player by username
+- `player` - When used as `/sls join player <player>`, connects you to the SLS server that player is currently on
 
 **Details:**
 - If no player argument is provided, the command executor is connected to the server
 - The command automatically handles server creation, starting, and waiting for readiness
 - Requires admin permission to join other players; players can join themselves without permission
+- `/sls join player <player>` is available to players and only works when the target player is currently on a registered SLS server
+
+---
+
+## Find Command
+
+**Permission:** None
+
+**Description:** Shows which SLS server a player is currently connected to.
+
+**Usage:**
+```
+/sls find <player>
+```
+
+**Details:**
+- Displays the player's current SLS composite server ID, such as `block_hunt.x82odk`
+- If the player is offline or not currently on an SLS server, the command displays an error message
 
 ---
 
@@ -523,4 +544,3 @@ All values are automatically formatted in appropriate units (KB, MB, GB, etc.) f
 - Tab completion is available for most commands to help with argument selection
 - Commands that interact with servers will display error messages if the server doesn't exist or is unavailable
 - Some commands (like `console`) have built-in retry mechanisms to handle asynchronous operations
-

--- a/vsls/pom.xml
+++ b/vsls/pom.xml
@@ -161,7 +161,7 @@
                         </goals>
                         <configuration>
                             <createDependencyReducedPom>true</createDependencyReducedPom>
-                            <outputFile>/home/jesse/Desktop/network/proxy/plugins/sls.jar</outputFile>
+                            <!-- <outputFile>/home/jesse/Desktop/network/proxy/plugins/sls.jar</outputFile> -->
                             <filters>
                                 <filter>
                                     <artifact>*:*</artifact>

--- a/vsls/pom.xml
+++ b/vsls/pom.xml
@@ -7,7 +7,7 @@
     <!-- Project Information -->
     <groupId>net.slimelabs</groupId>
     <artifactId>vsls</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
     <packaging>jar</packaging>
     <name>vsls</name>
 

--- a/vsls/src/main/java/net/slimelabs/vsls/SLS.java
+++ b/vsls/src/main/java/net/slimelabs/vsls/SLS.java
@@ -29,7 +29,7 @@ import static net.slimelabs.vsls.channel.MessageChannel.SLS_CHANNEL;
 @Plugin(
         id = "vsls",
         name = "vSLS",
-        version = "1.0.1",
+        version = "1.0.2",
         description = "Server Management Plugin",
         authors = {"Protoxon & Contributors"},
         dependencies = {

--- a/vsls/src/main/java/net/slimelabs/vsls/command/SLSCommand.java
+++ b/vsls/src/main/java/net/slimelabs/vsls/command/SLSCommand.java
@@ -51,6 +51,7 @@ public class SLSCommand {
         root.then(ResetCommand.register());      // RESET
         root.then(InfoCommand.register());       // INFO
         root.then(ListCommand.register());       // LIST
+        root.then(FindCommand.register());       // FIND
         root.then(SystemCommand.register());     // SYSTEM
         //root.then(TailCommand.register());     // TAIL
 
@@ -80,12 +81,12 @@ public class SLSCommand {
                             "join", "create", "start", "pause", "resume", "restart", "debug",
                             "stop", "kill", "reload", "status", "stats", "delete", "console",
                             "dequeue", "blueprint", "version", "logs", "node", "reset", "info",
-                            "list", "system"))
+                            "list", "find", "system"))
                     .sendMessage(source);
             return 1;
         } else {
             ProtoMessage.chat()
-                    .add(MessageFormatter.commandUsage("/sls", "join", "list", "dequeue"))
+                    .add(MessageFormatter.commandUsage("/sls", "join", "list", "find", "dequeue"))
                     .sendMessage(source);
         }
         return 0;

--- a/vsls/src/main/java/net/slimelabs/vsls/command/subcommand/FindCommand.java
+++ b/vsls/src/main/java/net/slimelabs/vsls/command/subcommand/FindCommand.java
@@ -1,0 +1,68 @@
+package net.slimelabs.vsls.command.subcommand;
+
+import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import com.mojang.brigadier.builder.RequiredArgumentBuilder;
+import com.velocitypowered.api.command.CommandSource;
+import com.velocitypowered.api.proxy.Player;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.slimelabs.vsls.SLS;
+import net.slimelabs.vsls.server.Server;
+import net.slimelabs.vsls.utils.ServerUtils;
+import net.slimelabs.vsls.utils.message.MessageFormatter;
+import net.slimelabs.vsls.utils.message.MessagePreset;
+import net.slimelabs.vsls.utils.message.ProtoMessage;
+
+import java.util.Optional;
+
+public class FindCommand {
+
+    public static LiteralArgumentBuilder<CommandSource> register() {
+        return LiteralArgumentBuilder.<CommandSource>literal("find")
+                .executes(context -> {
+                    CommandSource source = context.getSource();
+                    ProtoMessage.chat()
+                            .add(MessageFormatter.commandUsage("/sls find", "player"))
+                            .sendMessage(source);
+                    return 0;
+                })
+                .then(player());
+    }
+
+    private static RequiredArgumentBuilder<CommandSource, String> player() {
+        return RequiredArgumentBuilder.<CommandSource, String>argument("player", StringArgumentType.string())
+                .suggests((context, builder) -> {
+                    for (Player player : SLS.proxy.getAllPlayers()) {
+                        builder.suggest(player.getUsername());
+                    }
+                    return builder.buildFuture();
+                })
+                .executes(context -> {
+                    CommandSource source = context.getSource();
+                    String playerName = StringArgumentType.getString(context, "player");
+                    Optional<Player> player = SLS.proxy.getPlayer(playerName);
+                    if (player.isEmpty()) {
+                        ProtoMessage.chat()
+                                .add(MessagePreset.SLS)
+                                .add("Player " + playerName + " was not found.", NamedTextColor.RED)
+                                .sendMessage(source);
+                        return 0;
+                    }
+
+                    Server server = ServerUtils.getServer(player.get());
+                    if (server == null) {
+                        ProtoMessage.chat()
+                                .add(MessagePreset.SLS)
+                                .add("Player " + player.get().getUsername() + " is not on an SLS server.", NamedTextColor.RED)
+                                .sendMessage(source);
+                        return 0;
+                    }
+
+                    ProtoMessage.chat()
+                            .add(MessagePreset.SLS)
+                            .add("Player " + player.get().getUsername() + " is currently on " + server.getCompositeId(), NamedTextColor.DARK_AQUA)
+                            .sendMessage(source);
+                    return 1;
+                });
+    }
+}

--- a/vsls/src/main/java/net/slimelabs/vsls/command/subcommand/FindCommand.java
+++ b/vsls/src/main/java/net/slimelabs/vsls/command/subcommand/FindCommand.java
@@ -9,6 +9,7 @@ import net.kyori.adventure.text.format.NamedTextColor;
 import net.slimelabs.vsls.SLS;
 import net.slimelabs.vsls.server.Server;
 import net.slimelabs.vsls.utils.ServerUtils;
+import net.slimelabs.vsls.utils.message.CommandMessageParts;
 import net.slimelabs.vsls.utils.message.MessageFormatter;
 import net.slimelabs.vsls.utils.message.MessagePreset;
 import net.slimelabs.vsls.utils.message.ProtoMessage;
@@ -44,7 +45,10 @@ public class FindCommand {
                     if (player.isEmpty()) {
                         ProtoMessage.chat()
                                 .add(MessagePreset.SLS)
-                                .add("Player " + playerName + " was not found.", NamedTextColor.RED)
+                                .addMiniMessage("<red>Player</red> <dark_aqua>" + CommandMessageParts.text(playerName) + "</dark_aqua> <red>was not found.</red>")
+                                .sendMessage(source);
+                        ProtoMessage.actionBar()
+                                .add("Player not found: " + playerName, NamedTextColor.RED)
                                 .sendMessage(source);
                         return 0;
                     }
@@ -53,14 +57,22 @@ public class FindCommand {
                     if (server == null) {
                         ProtoMessage.chat()
                                 .add(MessagePreset.SLS)
-                                .add("Player " + player.get().getUsername() + " is not on an SLS server.", NamedTextColor.RED)
+                                .addMiniMessage(CommandMessageParts.player(player.get()) + " <red>is not on a vSLS server.</red> "
+                                        + "<dark_gray>Current server:</dark_gray> <gray>" + CommandMessageParts.text(ServerUtils.getServerName(player.get())) + "</gray>")
+                                .sendMessage(source);
+                        ProtoMessage.actionBar()
+                                .add(player.get().getUsername() + " is not on a vSLS server", NamedTextColor.RED)
                                 .sendMessage(source);
                         return 0;
                     }
 
                     ProtoMessage.chat()
                             .add(MessagePreset.SLS)
-                            .add("Player " + player.get().getUsername() + " is currently on " + server.getCompositeId(), NamedTextColor.DARK_AQUA)
+                            .addMiniMessage(CommandMessageParts.player(player.get())
+                                    + " <gray>is currently on</gray> " + CommandMessageParts.server(server))
+                            .sendMessage(source);
+                    ProtoMessage.actionBar()
+                            .add(player.get().getUsername() + " is on " + server.getCompositeId(), NamedTextColor.GREEN)
                             .sendMessage(source);
                     return 1;
                 });

--- a/vsls/src/main/java/net/slimelabs/vsls/command/subcommand/JoinCommand.java
+++ b/vsls/src/main/java/net/slimelabs/vsls/command/subcommand/JoinCommand.java
@@ -9,6 +9,7 @@ import net.kyori.adventure.text.format.NamedTextColor;
 import net.slimelabs.vsls.SLS;
 import net.slimelabs.vsls.log.Log;
 import net.slimelabs.vsls.server.Server;
+import net.slimelabs.vsls.utils.ServerUtils;
 import net.slimelabs.vsls.utils.message.MessageFormatter;
 import net.slimelabs.vsls.utils.message.MessagePreset;
 import net.slimelabs.vsls.utils.message.ProtoMessage;
@@ -24,11 +25,72 @@ public class JoinCommand {
                     CommandSource source = context.getSource();
                     ProtoMessage.chat().add(MessagePreset.INCORRECT_COMMAND_USAGE).sendMessage(source);
                     ProtoMessage.chat()
-                            .add(MessageFormatter.commandUsage("/sls join", "type"))
+                            .add(MessageFormatter.commandUsage("/sls join", "type", "player"))
                             .sendMessage(source);
                     return 1;
                 })
+                .then(joinPlayerServer())
                 .then(type());
+    }
+
+    private static LiteralArgumentBuilder<CommandSource> joinPlayerServer() {
+        return LiteralArgumentBuilder.<CommandSource>literal("player")
+                .executes(context -> {
+                    CommandSource source = context.getSource();
+                    ProtoMessage.chat()
+                            .add(MessageFormatter.commandUsage("/sls join player", "player"))
+                            .sendMessage(source);
+                    return 0;
+                })
+                .then(RequiredArgumentBuilder.<CommandSource, String>argument("target", StringArgumentType.string())
+                        .suggests((context, builder) -> {
+                            for (Player player : SLS.proxy.getAllPlayers()) {
+                                builder.suggest(player.getUsername());
+                            }
+                            return builder.buildFuture();
+                        })
+                        .executes(context -> {
+                            CommandSource source = context.getSource();
+                            if (!(source instanceof Player player)) {
+                                Log.error("You must be a player to join another player's server");
+                                return 0;
+                            }
+
+                            String targetName = StringArgumentType.getString(context, "target");
+                            Optional<Player> target = SLS.proxy.getPlayer(targetName);
+                            if (target.isEmpty()) {
+                                ProtoMessage.chat()
+                                        .add(MessagePreset.SLS)
+                                        .add("Player " + targetName + " was not found.", NamedTextColor.RED)
+                                        .sendMessage(source);
+                                return 0;
+                            }
+
+                            Server server = ServerUtils.getServer(target.get());
+                            if (server == null) {
+                                ProtoMessage.chat()
+                                        .add(MessagePreset.SLS)
+                                        .add("Player " + targetName + " is not on an SLS server.", NamedTextColor.RED)
+                                        .sendMessage(source);
+                                return 0;
+                            }
+
+                            Server currentServer = ServerUtils.getServer(player);
+                            if (currentServer != null && currentServer.getId().equals(server.getId())) {
+                                ProtoMessage.chat()
+                                        .add(MessagePreset.SLS)
+                                        .add("You are already on " + server.getCompositeId(), NamedTextColor.GRAY)
+                                        .sendMessage(source);
+                                return 1;
+                            }
+
+                            ProtoMessage.chat()
+                                    .add(MessagePreset.SLS)
+                                    .add("Joining " + target.get().getUsername() + "'s server " + server.getCompositeId(), NamedTextColor.DARK_AQUA)
+                                    .sendMessage(source);
+                            SLS.joinService.joinServer(player, server.getCompositeId());
+                            return 1;
+                        }));
     }
 
     private static RequiredArgumentBuilder<CommandSource, String> type() {

--- a/vsls/src/main/java/net/slimelabs/vsls/command/subcommand/JoinCommand.java
+++ b/vsls/src/main/java/net/slimelabs/vsls/command/subcommand/JoinCommand.java
@@ -3,13 +3,17 @@ package net.slimelabs.vsls.command.subcommand;
 import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.builder.RequiredArgumentBuilder;
+import com.mojang.brigadier.context.CommandContext;
 import com.velocitypowered.api.command.CommandSource;
 import com.velocitypowered.api.proxy.Player;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.slimelabs.vsls.SLS;
 import net.slimelabs.vsls.log.Log;
+import net.slimelabs.vsls.matchmaking.metadata.BlueprintMetadataParser;
+import net.slimelabs.vsls.matchmaking.metadata.MatchmakingMetadata;
 import net.slimelabs.vsls.server.Server;
 import net.slimelabs.vsls.utils.ServerUtils;
+import net.slimelabs.vsls.utils.message.CommandMessageParts;
 import net.slimelabs.vsls.utils.message.MessageFormatter;
 import net.slimelabs.vsls.utils.message.MessagePreset;
 import net.slimelabs.vsls.utils.message.ProtoMessage;
@@ -49,48 +53,105 @@ public class JoinCommand {
                             }
                             return builder.buildFuture();
                         })
-                        .executes(context -> {
-                            CommandSource source = context.getSource();
-                            if (!(source instanceof Player player)) {
-                                Log.error("You must be a player to join another player's server");
-                                return 0;
-                            }
+                        .executes(context -> joinPlayerServer(context, false))
+                        .then(LiteralArgumentBuilder.<CommandSource>literal("--force")
+                                .requires(source -> source.hasPermission("sls.command.admin"))
+                                .executes(context -> joinPlayerServer(context, true))));
+    }
 
-                            String targetName = StringArgumentType.getString(context, "target");
-                            Optional<Player> target = SLS.proxy.getPlayer(targetName);
-                            if (target.isEmpty()) {
-                                ProtoMessage.chat()
-                                        .add(MessagePreset.SLS)
-                                        .add("Player " + targetName + " was not found.", NamedTextColor.RED)
-                                        .sendMessage(source);
-                                return 0;
-                            }
+    private static int joinPlayerServer(CommandContext<CommandSource> context, boolean force) {
+        CommandSource source = context.getSource();
+        if (!(source instanceof Player player)) {
+            Log.error("You must be a player to join another player's server");
+            return 0;
+        }
 
-                            Server server = ServerUtils.getServer(target.get());
-                            if (server == null) {
-                                ProtoMessage.chat()
-                                        .add(MessagePreset.SLS)
-                                        .add("Player " + targetName + " is not on an SLS server.", NamedTextColor.RED)
-                                        .sendMessage(source);
-                                return 0;
-                            }
+        String targetName = StringArgumentType.getString(context, "target");
+        Optional<Player> target = SLS.proxy.getPlayer(targetName);
+        if (target.isEmpty()) {
+            ProtoMessage.chat()
+                    .add(MessagePreset.SLS)
+                    .addMiniMessage("<red>Player</red> <dark_aqua>" + CommandMessageParts.text(targetName) + "</dark_aqua> <red>was not found.</red>")
+                    .sendMessage(source);
+            ProtoMessage.actionBar()
+                    .add("Player not found: " + targetName, NamedTextColor.RED)
+                    .sendMessage(source);
+            return 0;
+        }
 
-                            Server currentServer = ServerUtils.getServer(player);
-                            if (currentServer != null && currentServer.getId().equals(server.getId())) {
-                                ProtoMessage.chat()
-                                        .add(MessagePreset.SLS)
-                                        .add("You are already on " + server.getCompositeId(), NamedTextColor.GRAY)
-                                        .sendMessage(source);
-                                return 1;
-                            }
+        Server server = ServerUtils.getServer(target.get());
+        if (server == null) {
+            ProtoMessage.chat()
+                    .add(MessagePreset.SLS)
+                    .addMiniMessage(CommandMessageParts.player(target.get()) + " <red>is not on a vSLS server.</red> "
+                            + "<dark_gray>Current server:</dark_gray> <gray>" + CommandMessageParts.text(ServerUtils.getServerName(target.get())) + "</gray>")
+                    .sendMessage(source);
+            ProtoMessage.actionBar()
+                    .add(target.get().getUsername() + " is not on a vSLS server", NamedTextColor.RED)
+                    .sendMessage(source);
+            return 0;
+        }
 
-                            ProtoMessage.chat()
-                                    .add(MessagePreset.SLS)
-                                    .add("Joining " + target.get().getUsername() + "'s server " + server.getCompositeId(), NamedTextColor.DARK_AQUA)
-                                    .sendMessage(source);
-                            SLS.joinService.joinServer(player, server.getCompositeId());
-                            return 1;
-                        }));
+        Server currentServer = ServerUtils.getServer(player);
+        if (currentServer != null && currentServer.getId().equals(server.getId())) {
+            ProtoMessage.chat()
+                    .add(MessagePreset.SLS)
+                    .addMiniMessage("<gray>You are already with</gray> " + CommandMessageParts.player(target.get())
+                            + " <gray>on</gray> " + CommandMessageParts.server(server) + "<gray>.</gray>")
+                    .sendMessage(source);
+            ProtoMessage.actionBar()
+                    .add("Already on " + server.getCompositeId(), NamedTextColor.GRAY)
+                    .sendMessage(source);
+            return 1;
+        }
+
+        int maxPlayers = getMaxPlayers(server);
+        if (!force && maxPlayers > 0 && server.getPlayerCount() >= maxPlayers) {
+            if (source.hasPermission("sls.command.admin")) {
+                String forceCommand = "/sls join player " + target.get().getUsername() + " --force";
+                ProtoMessage.chat()
+                        .add(MessagePreset.SLS)
+                        .addMiniMessage("<yellow>Blueprint limit warning:</yellow> "
+                                + CommandMessageParts.server(server) + " <gray>is full ("
+                                + server.getPlayerCount() + "/" + maxPlayers + ").</gray>\n"
+                                + "<dark_gray>Joining anyway may overfill this blueprint's matchmaking limit.</dark_gray> "
+                                + "<click:run_command:'" + CommandMessageParts.text(forceCommand) + "'><hover:show_text:'Run " + CommandMessageParts.text(forceCommand)
+                                + "'><green>[Join Anyway]</green></hover></click>")
+                        .sendMessage(source);
+                ProtoMessage.actionBar()
+                        .add("Confirm override to join " + server.getCompositeId(), NamedTextColor.YELLOW)
+                        .sendMessage(source);
+            } else {
+                ProtoMessage.chat()
+                        .add(MessagePreset.SLS)
+                        .addMiniMessage("<red>Server full:</red> " + CommandMessageParts.server(server)
+                                + " <gray>(" + server.getPlayerCount() + "/" + maxPlayers + ").</gray>")
+                        .sendMessage(source);
+                ProtoMessage.actionBar()
+                        .add("Server full: " + server.getCompositeId(), NamedTextColor.RED)
+                        .sendMessage(source);
+            }
+            return 0;
+        }
+
+        ProtoMessage.chat()
+                .add(MessagePreset.SLS)
+                .addMiniMessage((force ? "<yellow>Force joining</yellow> " : "<green>Joining</green> ")
+                        + CommandMessageParts.player(target.get())
+                        + " <gray>on</gray> " + CommandMessageParts.server(server) + "<gray>.</gray>")
+                .sendMessage(source);
+        ProtoMessage.actionBar()
+                .add((force ? "Force joining " : "Joining ") + target.get().getUsername() + " on " + server.getCompositeId(), force ? NamedTextColor.YELLOW : NamedTextColor.GREEN)
+                .sendMessage(source);
+        SLS.joinService.joinServer(player, server.getCompositeId(), force);
+        return 1;
+    }
+
+    private static int getMaxPlayers(Server server) {
+        var blueprint = SLS.blueprints.getBlueprint(server.getBlueprintId());
+        if (blueprint == null) return 0;
+        MatchmakingMetadata metadata = BlueprintMetadataParser.parse(blueprint);
+        return metadata != null ? metadata.maxPlayers() : 0;
     }
 
     private static RequiredArgumentBuilder<CommandSource, String> type() {

--- a/vsls/src/main/java/net/slimelabs/vsls/matchmaking/join/DirectServerJoiner.java
+++ b/vsls/src/main/java/net/slimelabs/vsls/matchmaking/join/DirectServerJoiner.java
@@ -4,7 +4,10 @@ import com.protoxon.S4J.ServerStatus;
 import com.velocitypowered.api.proxy.Player;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.slimelabs.vsls.SLS;
+import net.slimelabs.vsls.matchmaking.metadata.BlueprintMetadataParser;
+import net.slimelabs.vsls.matchmaking.metadata.MatchmakingMetadata;
 import net.slimelabs.vsls.server.Server;
+import net.slimelabs.vsls.utils.message.CommandMessageParts;
 import net.slimelabs.vsls.utils.message.MessagePreset;
 import net.slimelabs.vsls.utils.message.ProtoMessage;
 
@@ -21,6 +24,10 @@ public class DirectServerJoiner {
     private final Map<String, ServerConnectionQueue> queues = new ConcurrentHashMap<>();
 
     public void join(Player player, String serverId) {
+        join(player, serverId, false);
+    }
+
+    public void join(Player player, String serverId, boolean ignoreBlueprintRules) {
         Server server = SLS.servers.getServer(serverId);
         if (server == null) {
             server = SLS.servers.resolve(serverId);
@@ -28,8 +35,13 @@ public class DirectServerJoiner {
         if (server == null) {
             ProtoMessage.chat()
                     .add(MessagePreset.SLS)
-                    .add("Error: Server not found", NamedTextColor.RED)
+                    .addMiniMessage("<red>Server not found.</red>")
                     .sendMessage(player);
+            return;
+        }
+
+        ServerConnectionQueue existingQueue = queues.get(server.getId());
+        if (!ignoreBlueprintRules && !hasCapacity(player, server, existingQueue)) {
             return;
         }
 
@@ -39,11 +51,11 @@ public class DirectServerJoiner {
         }
 
         final Server s = server;
-        ServerConnectionQueue existingForTarget = queues.get(s.getId());
+        ServerConnectionQueue existingForTarget = existingQueue;
         if (existingForTarget != null && existingForTarget.isQueued(player)) {
             ProtoMessage.chat()
                     .add(MessagePreset.SLS)
-                    .addMiniMessage("<gradient:#9d70ff:#00ffff>You are already in queue for " + s.getName() + "</gradient>")
+                    .addMiniMessage("<gray>You are already in queue for</gray> " + CommandMessageParts.server(s) + "<gray>.</gray>")
                     .sendMessage(player);
             return;
         }
@@ -53,7 +65,7 @@ public class DirectServerJoiner {
                 s.getId(),
                 id -> new ServerConnectionQueue(s, () -> queues.remove(s.getId()), true)
         );
-        queue.enqueue(player);
+        queue.enqueue(player, ignoreBlueprintRules);
     }
 
     /**
@@ -61,16 +73,19 @@ public class DirectServerJoiner {
      * Use for reset/restart flows where the server is already starting.
      */
     public void joinWhenReady(Player player, Server server) {
+        ServerConnectionQueue existingForTarget = queues.get(server.getId());
+        if (!hasCapacity(player, server, existingForTarget)) {
+            return;
+        }
         if (server.getStatus() == com.protoxon.S4J.ServerStatus.RUNNING) {
             server.connect(player);
             return;
         }
         final Server s = server;
-        ServerConnectionQueue existingForTarget = queues.get(s.getId());
         if (existingForTarget != null && existingForTarget.isQueued(player)) {
             ProtoMessage.chat()
                     .add(MessagePreset.SLS)
-                    .addMiniMessage("<gradient:#9d70ff:#00ffff>You are already in queue for " + s.getName() + "</gradient>")
+                    .addMiniMessage("<gray>You are already in queue for</gray> " + CommandMessageParts.server(s) + "<gray>.</gray>")
                     .sendMessage(player);
             return;
         }
@@ -89,5 +104,33 @@ public class DirectServerJoiner {
             if (queue.dequeue(player)) return true;
         }
         return false;
+    }
+
+    private boolean hasCapacity(Player player, Server server, ServerConnectionQueue queue) {
+        int maxPlayers = getMaxPlayers(server);
+        if (maxPlayers <= 0) return true;
+
+        int online = server.getPlayerCount();
+        int queued = queue != null ? queue.getWaitingCount() : 0;
+        if (online + queued < maxPlayers) return true;
+
+        ProtoMessage.chat()
+                .add(MessagePreset.SLS)
+                .addMiniMessage("<red>Server full:</red> " + CommandMessageParts.server(server)
+                        + " <gray>(" + online + " online")
+                .addMiniMessage(queued > 0 ? ", " + queued + " queued" : "")
+                .addMiniMessage(", max " + maxPlayers + ").</gray>")
+                .sendMessage(player);
+        ProtoMessage.actionBar()
+                .add("Server full: " + server.getCompositeId(), NamedTextColor.RED)
+                .sendMessage(player);
+        return false;
+    }
+
+    private int getMaxPlayers(Server server) {
+        var blueprint = SLS.blueprints.getBlueprint(server.getBlueprintId());
+        if (blueprint == null) return 0;
+        MatchmakingMetadata metadata = BlueprintMetadataParser.parse(blueprint);
+        return metadata != null ? metadata.maxPlayers() : 0;
     }
 }

--- a/vsls/src/main/java/net/slimelabs/vsls/matchmaking/join/JoinService.java
+++ b/vsls/src/main/java/net/slimelabs/vsls/matchmaking/join/JoinService.java
@@ -39,6 +39,14 @@ public class JoinService {
         direct.join(player, serverId);
     }
 
+    /**
+     * Connects the player directly to the server, optionally ignoring blueprint capacity rules.
+     */
+    public void joinServer(Player player, String serverId, boolean ignoreBlueprintRules) {
+        matchmaking.dequeue(player);
+        direct.join(player, serverId, ignoreBlueprintRules);
+    }
+
     /** Queues the player for matchmaking on the given blueprint. */
     public void joinBlueprint(Player player, String blueprintId) {
         direct.dequeue(player);

--- a/vsls/src/main/java/net/slimelabs/vsls/matchmaking/join/ServerConnectionQueue.java
+++ b/vsls/src/main/java/net/slimelabs/vsls/matchmaking/join/ServerConnectionQueue.java
@@ -7,15 +7,20 @@ import net.kyori.adventure.text.format.NamedTextColor;
 import net.slimelabs.vsls.SLS;
 import net.slimelabs.vsls.log.Log;
 import net.slimelabs.vsls.events.Event;
+import net.slimelabs.vsls.matchmaking.metadata.BlueprintMetadataParser;
+import net.slimelabs.vsls.matchmaking.metadata.MatchmakingMetadata;
 import net.slimelabs.vsls.packets.ChatPackets;
 import net.slimelabs.vsls.server.Server;
 import net.slimelabs.vsls.utils.loader.Animation;
+import net.slimelabs.vsls.utils.message.CommandMessageParts;
 import net.slimelabs.vsls.utils.message.MessagePreset;
 import net.slimelabs.vsls.utils.message.ProtoMessage;
 
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Queue for a single server: wait until RUNNING then connect all waiting players.
@@ -35,6 +40,7 @@ public class ServerConnectionQueue {
     private final boolean startServer;
     private final Runnable onClosed;
     private final ConcurrentLinkedQueue<Player> waiting = new ConcurrentLinkedQueue<>();
+    private final Set<java.util.UUID> ignoreBlueprintRules = ConcurrentHashMap.newKeySet();
     private final Animation loadingIcon = new Animation();
     private final AtomicBoolean flushed = new AtomicBoolean(false);
     private final Event.Handle statusHandle;
@@ -83,13 +89,28 @@ public class ServerConnectionQueue {
         statusHandle.remove();
         deletionHandle.remove();
         onClosed.run();
+        int connected = 0;
+        int maxPlayers = getMaxPlayers();
         for (Player p : waiting) {
-            ProtoMessage.actionBar().add("Joining " + server.getName(), NamedTextColor.GREEN).sendMessage(p);
             ChatPackets.enableActionBarPackets(p.getUniqueId());
             loadingIcon.stop(p.getUniqueId());
+            if (!ignoreBlueprintRules.contains(p.getUniqueId()) && maxPlayers > 0 && server.getPlayerCount() + connected >= maxPlayers) {
+                ProtoMessage.chat()
+                        .add(MessagePreset.SLS)
+                        .addMiniMessage("<red>Server full:</red> " + CommandMessageParts.server(server)
+                                + " <gray>(max " + maxPlayers + ").</gray>")
+                        .sendMessage(p);
+                ProtoMessage.actionBar()
+                        .add("Server full: " + server.getCompositeId(), NamedTextColor.RED)
+                        .sendMessage(p);
+                continue;
+            }
+            ProtoMessage.actionBar().add("Joining " + server.getName(), NamedTextColor.GREEN).sendMessage(p);
             server.connect(p);
+            connected++;
         }
         waiting.clear();
+        ignoreBlueprintRules.clear();
     }
 
     private void flushWithError(String message) {
@@ -103,6 +124,7 @@ public class ServerConnectionQueue {
             loadingIcon.stop(p.getUniqueId());
         }
         waiting.clear();
+        ignoreBlueprintRules.clear();
     }
 
     private void flushWithApiError(String message, ApiFailure failure) {
@@ -116,10 +138,18 @@ public class ServerConnectionQueue {
             loadingIcon.stop(p.getUniqueId());
         }
         waiting.clear();
+        ignoreBlueprintRules.clear();
     }
 
     public void enqueue(Player player) {
+        enqueue(player, false);
+    }
+
+    public void enqueue(Player player, boolean ignoreBlueprintRules) {
         waiting.add(player);
+        if (ignoreBlueprintRules) {
+            this.ignoreBlueprintRules.add(player.getUniqueId());
+        }
         loadingIcon.start(player);
         ProtoMessage.chat()
                 .add(MessagePreset.SLS)
@@ -132,6 +162,7 @@ public class ServerConnectionQueue {
         loadingIcon.stop(player.getUniqueId());
         ChatPackets.enableActionBarPackets(player.getUniqueId());
         boolean removed = waiting.remove(player);
+        ignoreBlueprintRules.remove(player.getUniqueId());
         if (removed && waiting.isEmpty()) {
             statusHandle.remove();
             deletionHandle.remove();
@@ -146,5 +177,16 @@ public class ServerConnectionQueue {
 
     public boolean isQueued(Player player) {
         return waiting.contains(player);
+    }
+
+    public int getWaitingCount() {
+        return waiting.size();
+    }
+
+    private int getMaxPlayers() {
+        var blueprint = SLS.blueprints.getBlueprint(server.getBlueprintId());
+        if (blueprint == null) return 0;
+        MatchmakingMetadata metadata = BlueprintMetadataParser.parse(blueprint);
+        return metadata != null ? metadata.maxPlayers() : 0;
     }
 }

--- a/vsls/src/main/java/net/slimelabs/vsls/utils/message/CommandMessageParts.java
+++ b/vsls/src/main/java/net/slimelabs/vsls/utils/message/CommandMessageParts.java
@@ -1,0 +1,43 @@
+package net.slimelabs.vsls.utils.message;
+
+import com.velocitypowered.api.proxy.Player;
+import net.kyori.adventure.text.minimessage.MiniMessage;
+import net.slimelabs.vsls.server.Server;
+
+public final class CommandMessageParts {
+
+    private CommandMessageParts() {}
+
+    public static String player(Player player) {
+        String currentServer = player.getCurrentServer()
+                .map(connection -> connection.getServerInfo().getName())
+                .orElse("none");
+        return "<hover:show_text:'<dark_gray>UUID:</dark_gray> <gray>" + escape(player.getUniqueId().toString()) + "</gray>\n"
+                + "<dark_gray>Current server:</dark_gray> <gray>" + escape(currentServer) + "</gray>'>"
+                + "<dark_aqua>" + escape(player.getUsername()) + "</dark_aqua></hover>";
+    }
+
+    public static String server(Server server) {
+        String compositeId = server.getCompositeId();
+        String prefix = compositeId;
+        String suffix = "";
+        int dot = compositeId.lastIndexOf('.');
+        if (dot >= 0) {
+            prefix = compositeId.substring(0, dot);
+            suffix = compositeId.substring(dot);
+        }
+        return "<hover:show_text:'<dark_gray>Name:</dark_gray> <gray>" + escape(server.getName()) + "</gray>\n"
+                + "<dark_gray>Blueprint:</dark_gray> <gray>" + escape(server.getBlueprintId()) + "</gray>\n"
+                + "<dark_gray>Status:</dark_gray> <gray>" + escape(server.getStatus().getStatus()) + "</gray>\n"
+                + "<dark_gray>Players:</dark_gray> <gray>" + server.getPlayerCount() + "</gray>'>"
+                + "<gold>" + escape(prefix) + "</gold><yellow>" + escape(suffix) + "</yellow></hover>";
+    }
+
+    public static String text(String value) {
+        return escape(value);
+    }
+
+    private static String escape(String value) {
+        return MiniMessage.miniMessage().escapeTags(value == null ? "" : value);
+    }
+}


### PR DESCRIPTION
## Summary

Adds player-targeted joining and lookup commands to vSLS.

### New commands

- `/sls join player <player>`
  - Connects the command sender to the vSLS server that the target player is currently on.
  - Respects blueprint matchmaking capacity rules for normal players.

- `/sls find <player>`
  - Shows which vSLS server a player is currently connected to.

### Admin override behavior

If an admin tries to join a player on a server that is already at its blueprint `matchmaking.maxPlayers` limit, vSLS now shows a warning instead of silently blocking the join.

The warning explains that the server is full according to the blueprint rules and provides a clickable `Join Anyway` confirmation. This runs:

```mcfunction
/sls join player <player> --force
```

`--force` requires `sls.command.admin` and allows admins to intentionally bypass blueprint capacity limits for direct player-follow joins.

### Blueprint rule handling

Direct server joins now check blueprint matchmaking metadata before connecting:

- Normal players cannot join a target server past its configured `annotations.vsls.matchmaking.maxPlayers`.
- Players queued for a direct join also count toward the effective capacity while a server is starting.
- Capacity is checked again when the server becomes ready, so population changes during startup are handled safely.
- Existing blueprint `on-join` behavior still runs normally after the player connects.

### Chat UX improvements

The new join/find messages were styled to match existing vSLS command output:

- Player names use `dark_aqua`.
- Server IDs use a split color format:
  - blueprint/prefix in `gold`
  - short server suffix in `yellow`
- Error details use red/gray styling consistent with other commands.
- No bold text is used.

Player and server references are hoverable:

- Hovering a player shows UUID and current server.
- Hovering a server shows server name, blueprint ID, status, and player count.

Dynamic MiniMessage text is escaped for the new hover/message helpers so server names, blueprint IDs, and other dynamic values cannot accidentally be parsed as formatting.

### Docs

Updated documentation for:

- `/sls join player <player>`
- `/sls join player <player> --force`
- `/sls find <player>`
- Admin override permission behavior
- Hover details in chat output

Also added the new player-facing commands to the vSLS README for discoverability.

### Version

Bumped vSLS to `1.0.2` in:

- `vsls/pom.xml`
- Velocity `@Plugin` metadata